### PR TITLE
-rm direct links to GGroup/ Slack; clarifying onboarding

### DIFF
--- a/discovery/web/templates/index.html
+++ b/discovery/web/templates/index.html
@@ -68,7 +68,7 @@
             <h3 class="text-muted lighter caps" id="get-involved">Get Involved!</h3>
             <img class="margin20" src="./static/img/cd2h-logo.png" width="200px" alt="logo"/>
             <p class="text-muted w-75 m-auto lighter">
-              The CD2H project uses this form to collect information that is necessary for the management, operation and functioning of contributors to CD2H projects and working groups. Please fill in as much information as possible and <a target="_blank" href="mailto:data2health@gmail.com">contact us</a> if you have any questions.
+              The CD2H project uses the onboarding form to track community interest and engagement in CD2H projects and working groups. You are welcome to participate at any level, whether contributing requirements, code, or just casually following the project as it progresses. Simply check the box indicating you're interested in the 'discovery engine', we will get in touch. <a target="_blank" href="mailto:data2health@gmail.com">Contact us</a> if you have any questions.
             </p>
             <a target="_blank" href="http://bit.ly/cd2h-onboarding-form" role="button" class="btn themeButton pulse text-light mt-4">Join Now</a>
           </div>
@@ -88,23 +88,7 @@
                 <a class="mainTextDark" target="_blank" href="https://github.com/data2health/rdp-portal"> Reusable Data best practice portal (rdp-portal)</a>
               </dt>
               <dd class="lighter">
-                Contribute to our reserach on GitHub
-              </dd>
-              <dt>
-                <img src="/static/img/slack.png" width="40px" alt="logo"/>
-                <br />
-                <a class="mainTextDark" target="_blank" href="https://cd2h.slack.com/messages/CEY05KLPM "> Slack Channel #Metadata</a>
-              </dt>
-              <dd class="lighter">
-                Join the conversation and our biweekly meetings
-              </dd>
-              <dt>
-                <img src="/static/img/gg.png" width="40px" alt="logo"/>
-                <br />
-                <a class="mainTextDark" target="_blank" href="mailto:cd2h-metadata@googlegroups.com "><i class="fas fa-envelope"></i> Google Group</a>
-              </dt>
-              <dd class="lighter">
-                Join <a target="_blank" href="https://groups.google.com/forum/#!forum/cd2h-metadata" rel="noreferrer">our group</a> and learn more!
+                Learn more about our project on GitHub
               </dd>
             </dl>
           </div>


### PR DESCRIPTION
1) The slack channel is available to onboarded participants only, I would hide this from the website
2) The google group is not configured to be directly joined or mailed. I would recommend removing this too. Rather have people onboard and you can add them from there.