### PR TITLE
fix: :sparkles: identify schema classes and pull from schema namespace

### DIFF
--- a/discovery/web/templates/schema-editor.html
+++ b/discovery/web/templates/schema-editor.html
@@ -1101,7 +1101,12 @@ const store = new Vuex.Store({
       // console.log('pList',pList)
       for (var i = 0; i < pList.length; i++) {
         state.loading = true;
-        let url = "api/registry/"+state.schema[0].namespace+"/"+pList[i]
+        let namespace = state.schema[0].namespace;
+        let curie = pList[i];
+        // check if curie is from schema.org and change if necessary
+        namespace = curie.includes('schema:') ? 'schema' : namespace;
+        console.log('getting parents', namespace)
+        let url = "api/registry/"+namespace+"/"+curie
         axios.get(url).then(res=>{
           if (res.data) {
             commit('saveParent',{'parent':res.data})

--- a/discovery/web/templates/schema-editor.html
+++ b/discovery/web/templates/schema-editor.html
@@ -1103,8 +1103,8 @@ const store = new Vuex.Store({
         state.loading = true;
         let namespace = state.schema[0].namespace;
         let curie = pList[i];
-        // check if curie is from schema.org and change if necessary
-        namespace = curie.includes('schema:') ? 'schema' : namespace;
+        //pull definition from registered namespace - should match curie prefix
+        namespace = curie.split(":")[0];
         console.log('getting parents', namespace)
         let url = "api/registry/"+namespace+"/"+curie
         axios.get(url).then(res=>{


### PR DESCRIPTION
Fixes missing classes and missing properties of schema.org classes due to trying to pull their definitions from wrong namespace.  Frontend will correct the namespace if a schema.org curie is detected.

<img width="801" alt="Screen Shot 2021-11-17 at 11 48 47 AM" src="https://user-images.githubusercontent.com/23092057/142272678-a8598c68-0a8b-4283-95e4-31849fe7317e.png">
