### PR TITLE
feat: :sparkles: browse by namapespace, improve pagination

### DIFF
--- a/templates/registry.html
+++ b/templates/registry.html
@@ -1,111 +1,141 @@
 {% extends "main.html" %}
 {% block content %}
 {% include "header.html" %}
-<div id="registry" class="jumbotron" style="min-height:80vh;">
+<div id="registry" class="jumbotron bg-white" style="min-height:80vh;">
   <div v-if=loading class="loader">
     <img src="/static/img/ripple.svg"/>
   </div>
   <div class="container">
 
-    <div class="">
+    <div>
       <h1 class="text-center logoText mb-1 mt-2">Schema Registry</h1>
-      <div class="alert alert-secondary p-1 rounded">
-        <div class="">
-          <small class="bold text-muted">SHORTCUTS</small>
-          <template v-for="item in shortcuts">
-            <div class="pillType d-inline pointer m-1" @click.prevent="window.location.href='/view/'+item.registered_namespace+'/'" :data-tippy="'Visualize Classes in '+item.name" data-tippy-theme="light">
-              <span class="mainBackDark">Visualize <i class="fas fa-eye"></i></span>
-              <span v-text="item.name"></span>
+      <ul class="nav nav-tabs" id="myTab" role="tablist">
+        <li class="nav-item" role="presentation">
+          <a class="nav-link active mainTextLight" id="class-tab" data-toggle="tab" href="#classes" role="tab" aria-controls="classes" aria-selected="true">Search By Class Name</a>
+        </li>
+        <li class="nav-item" role="presentation" @click="getNameSpaces()">
+          <a class="nav-link mainTextDark" id="namespace-tab" data-toggle="tab" href="#namespaces" role="tab" aria-controls="namespaces" aria-selected="false">Browse By Namespace</a>
+        </li>
+      </ul>
+      <div class="tab-content p-0 m-0" id="myTabContent">
+        <!-- 🌈  CLASS SEARCH 🌈 -->
+        <div class="tab-pane fade show active" id="classes" role="tabpanel" aria-labelledby="class-tab">
+          <div class="p-2 alert-secondary">
+            <div class="alert alert-light jumbotron">
+              <h2 class="logoText">Classes</h2>
+              <p>Visualize (<i class="fas fa-eye text-info"></i>), extend (<i class="fas fa-code-branch mainTextLight"></i>) and compare (<i class="fas fa-not-equal mainTextDark"></i>) available schema classes.</p>
             </div>
-          </template>
-          <template v-for='item in startingPoints'>
-            <preset-box :preset='item'></preset-box>
-          </template>
-        </div>
-      </div>
-      <!-- <div v-if="compareItems.length" class="d-flex justify-content-around align-items-center p-1 alert grad mt-2">
-        <template v-for="item in compareItems">
-          <div :key="item.label" class="flip-in-ver-left badge badge-light" :style="'border: 3px solid'+item.color">
-            <span v-text="item.name"></span>
-          </div>
-        </template>
-        <div>
-          <button :disabled="compareItems.length > 1?false:true" @click="compareAll()" v-if="compareItems.length" class="btn btn-success mr-1">Complete</button>
-          <button :disabled="compareItems.length > 1?false:true" @click="compareUsed()" v-if="compareItems.length" class="btn btn-success mr-1">Used Only</button>
-        </div>
-      </div> -->
-      <div class="mt-4">
-        <form @submit.prevent="search()">
-          <div class="row m-0 cBox actions bg-secondary rounded">
-            <div class="col-sm-9 p-2">
-              <div class="d-flex align-item-center">
-                <div>
-                  <small class="text-light px-2" v-text="total+' Results'"></small>
+            <div>
+              <form @submit.prevent="search()">
+                <div class="row m-0 cBox actions bg-secondary rounded">
+                  <div class="col-sm-9 p-2">
+                    <div class="d-flex align-item-center">
+                      <div>
+                        <small class="text-light px-2" v-text="total+' Results'"></small>
+                      </div>
+                      <input class="form-control col-10" id="search_query" type="text" v-model="query" name="query" placeholder="Search..." >
+                    </div>
+                  </div>
+                  <div class="col-sm-3 p-2 bg-dark actions d-flex align-items-center justify-content-around">
+                    <span class="fa-stack fa-1x pointer search unselectable tip" @click.prevent="search()">
+                      <i class="fas fa-circle text-muted fa-stack-2x"></i>
+                      <i class="fas fa-search fa-stack-1x text-light"></i>
+                    </span>
+                    <span class="fa-stack fa-1x pointer reset unselectable" @click.prevent="window.location.reload()">
+                      <i class="fas fa-circle fa-stack-2x text-danger"></i>
+                      <i class="fas fa-undo fa-stack-1x text-light"></i>
+                    </span>
+                    <span class="fa-stack fa-1x pointer unselectable compare" @click="openModal()">
+                      <i class="fas fa-circle fa-stack-2x mainTextDark"></i>
+                      <i class="fas fa-not-equal fa-stack-1x text-light"></i>
+                    </span>
+                  </div>
                 </div>
-                <input class="form-control col-10" id="search_query" type="text" v-model="query" name="query" placeholder="Search..." >
+              </form>
+            </div>
+            <div class="text-right d-none d-md-block">
+              <label class="text-muted mr-2" for="exampleFormControlSelect1"><small>Order</small></label>
+              <select class="form-control form-control-sm w-25 float-right" id="exampleFormControlSelect1" @change="search()" v-model="sortChange">
+                <option>Choose one</option>
+                <option value="relevance">Relevance</option>
+                <option value="A-Z">Alphabetically A-Z</option>
+                <option value="Z-A">Alphabetically Z-A</option>
+              </select>
+            </div>
+            <div class="d-flex align-item-center justify-content-between px-3 text-muted">
+              <small>Compare (Max 4)</small>
+              <small>Details | <img src='/static/img/cube.svg' width="15px"> (validation available)</small> 
+              <small>View/Extend</small>
+            </div>
+            <ul class="list-group context" id="regTippyParent">
+              <template v-if="registry.length" v-for="item in registry">
+                <registry-item :item='item' :key="item._id"></registry-item>
+              </template>
+            </ul>
+            <div>
+              <select class="form-control form-control-sm m-auto w-25" v-model="perPage" @change="calculatePages" id="perPage">
+                  <option value="" disabled selected>Shown Per Page</option>
+                  <option value="10">10 per page</option>
+                  <option value="25">25 per page</option>
+                  <option value="100">100 per page</option>
+              </select>
+              <div class="d-flex flex-wrap justify-content-center p-1 mt-2">
+                <div class="page-item rounded-0" :class="{ 'disabled': page <= 1 }">
+                  <a class="page-link p-1" @click.prevent="prevPage(); search()"><i class="fas fa-step-backward"></i></a>
+                </div>
+                <template v-if="groupPages">
+                  <div class="page-item rounded-0" v-show="!startCapLimitReached">
+                    <a href="#" class="page-link p-1" @click.prevent="previousGroup(); search()">Previous 20</a>
+                  </div>
+                </template>
+                <template v-for="n in pages">
+                  <div v-if="n >= startCap && n <= endCap" class="page-item rounded-0" :class="{ 'active': page == n, 'bg-primary': page == n, 'white-text': page == n  }">
+                    <a href="#" class="page-link p-1" @click.prevent="page = n; search()" v-text="n"></a>
+                  </div>
+                </template>
+                <template v-if="groupPages">
+                  <div class="page-item rounded-0" v-show="!endCapLimitReached">
+                    <a href="#" class="page-link p-1" @click.prevent="nextGroup(); search()">Next 20</a>
+                  </div>
+                </template>
+                <div class="page-item rounded-0" :class="{ 'disabled': page >= pages }">
+                  <a class="page-link p-1" @click.prevent="nextPage(); search()"><i class="fas fa-step-forward"></i></a>
+                </div>
               </div>
             </div>
-            <div class="col-sm-3 p-2 bg-dark actions d-flex align-items-center justify-content-around">
-              <span class="fa-stack fa-1x pointer search unselectable tip" @click.prevent="search()">
-                <i class="fas fa-circle text-muted fa-stack-2x"></i>
-                <i class="fas fa-search fa-stack-1x text-light"></i>
-              </span>
-              <span class="fa-stack fa-1x pointer reset unselectable" @click.prevent="window.location.reload()">
-                <i class="fas fa-circle fa-stack-2x text-danger"></i>
-                <i class="fas fa-undo fa-stack-1x text-light"></i>
-              </span>
-              <span class="fa-stack fa-1x pointer unselectable compare" @click="openModal()">
-                <i class="fas fa-circle fa-stack-2x mainTextDark"></i>
-                <i class="fas fa-not-equal fa-stack-1x text-light"></i>
-              </span>
-            </div>
+
           </div>
-        </form>
-      </div>
-      <div class="text-right d-none d-md-block">
-        <label class="text-muted mr-2" for="exampleFormControlSelect1"><small>Order</small></label>
-        <select class="form-control form-control-sm w-25 float-right" id="exampleFormControlSelect1" @change="search()" v-model="sortChange">
-          <option>Choose one</option>
-          <option value="relevance">Relevance</option>
-          <option value="A-Z">Alphabetically A-Z</option>
-          <option value="Z-A">Alphabetically Z-A</option>
-        </select>
-      </div>
-      <div class="d-flex align-item-center justify-content-between px-3 text-muted">
-        <small>Compare (Max 4)</small>
-        <small>Details | <span class="badge badge-success mr-1 bold">V</span> validation available</small>
-        <small>View/Extend</small>
-      </div>
-      <ul class="list-group context" id="regTippyParent">
-        <template v-if="registry.length" v-for="item in registry">
-          <registry-item :item='item' :key="item._id"></registry-item>
-        </template>
-      </ul>
-      <div class="bg-light">
-        <div class="row">
-          <nav class="m-auto ">
-            <ul class="pagination m-2 flex-wrap p-2">
-              <li class="page-item" :class="{ 'disabled': page <= 1 }">
-                <a class="page-link" @click.prevent="prevPage(); search()"><i class="fas fa-step-backward"></i></a>
-              </li>
-              <li class="page-item" :class="{ 'active': page == n, 'bg-primary': page == n, 'white-text': page == n  }" v-for="n in pages">
-                <a href="#" class="page-link" @click.prevent="page = n; search()" v-text="n"></a>
-              </li>
-              <li class="page-item" :class="{ 'disabled': page >= pages }">
-                <a class="page-link" @click.prevent="nextPage(); search()"><i class="fas fa-step-forward"></i></a>
+        </div>
+        <!-- 🌈  NAMESPACE 🌈 -->
+        <div class="tab-pane fade" id="namespaces" role="tabpanel" aria-labelledby="namespace-tab">
+          <div class="p-2 alert-dark">
+            <div class="alert alert-light jumbotron">
+              <h2 class="logoText">Namespaces</h2>
+              <p>Browse registered namespaces and view their available schema classes and properties.</p>
+            </div>
+            <ul class="pagination overflow-x-scroll mt-3" v-show="classesGroupByLetter.length>5">
+              <li class="page-link" v-for="(item,i) in classesGroupByLetter">
+                <a :href="'#'+item.group" v-text="item.group"></a>
               </li>
             </ul>
-          </nav>
-          <div class="col-sm-12 right-align form-group">
-            <select class="perPage form-control form-control-sm w-50 m-auto" v-model="perPage" @change="calculatePages" id="perPage">
-                <option value="" disabled selected>Shown Per Page</option>
-                <option value="20">20 per page</option>
-                <option value="50">50 per page</option>
-                <option value="100">100 per page</option>
-            </select>
+            <div style="overflow-y: scroll; max-height: 600px;">
+              <ul class="list-group mt-3">
+                <li class="list-group-item list-group-item-action" v-for="(item,i) in classesGroupByLetter">
+                  <h3 :id="item.group" class="text-dark" v-text="item.group " v-show="classesGroupByLetter.length>5"></h3>
+                  <ul style="list-style:none;">
+                    <li v-for="def in item.children">
+                      <a  :href="'/view/'+def">
+                        <span v-text="def"></span> <i class="fas fa-chevron-right"></i>
+                      </a>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
+
     </div>
   </div>
 
@@ -690,16 +720,11 @@ Vue.component('registry-item', {
           <h6 class="m-1 mainTextDark d-inline">
             </span> <span v-text="item.label"></span> <small><i :id="item.label" class="fas fa-info-circle text-info"></i></small>
           </h6>
-          <ul v-if="expand" class="mainTextLight">
-            <li v-for="prop in item.properties" :key="prop.label">
-              <small v-text="prop.label"></small>
-            </li>
-          </ul>
         </div>
         <p class="m-0 text-muted d-none d-md-inline">
           <small class="pointer" @click="expand=!expand">
             <span :class="[propTotal>0?'text-primary':'text-muted']"><span v-text="propTotal"></span> Properties</span>
-            <i v-show="propTotal" class="fas" :class="[!expand?'fa-plus-square':'fa-minus-square']"></i>
+            <i v-show="propTotal" class="fas" :class="[!expand?'fa-plus-square text-success':'fa-minus-square text-danger']"></i>
           </small>
            |
           <small><i class="fas fa-home"></i>: </small>
@@ -709,22 +734,27 @@ Vue.component('registry-item', {
            |
           <small>Subclass of:</small>
           <small class="mb-1" v-text="getSubclass(item.parent_classes)"></small>
-          <small v-if="item && item.validation" class="badge badge-success mr-1">V</small>
+          <img v-if="item && item.validation" src='/static/img/cube.svg' width="15px" title="validation available">
         </p>
       </div>
       <div class="p-1 bg-dark d-flex align-items-center justify-content-around">
         <div>
           <span class="fa-stack fa-1x pointer tip mr-2 ml-2" @click.prevent="saveDataAndRedirect(item)" :data-tippy-info="'Visualize '+item.label">
-            <i class="fas fa-circle text-muted fa-stack-2x"></i>
+            <i class="fas fa-circle text-info fa-stack-2x"></i>
             <i class="fas fa-eye fa-stack-1x text-light"></i>
           </span>
         </div>
         <div>
           <span class="fa-stack fa-1x pointer tip mr-2 ml-2" @click.prevent="saveDataAndRedirect(item,'editor')" :data-tippy-info="'Extend '+item.label">
-            <i class="fas fa-circle text-muted fa-stack-2x"></i>
+            <i class="fas fa-circle mainTextLight fa-stack-2x"></i>
             <i class="fas fa-code-branch fa-stack-1x text-light"></i>
           </span>
         </div>
+      </div>
+      <div class="col-sm-12 alert alert-info d-flex flex-wrap m-0" v-if="expand">
+        <template v-for="prop,i in item.properties" :key="prop.label">
+          <small class="mr-1" v-text="i + 1 < item.properties.length ? prop.label + ', ' : prop.label"></small>
+        </template>
       </div>
     </div>
   </li>`
@@ -744,16 +774,42 @@ var app = new Vue({
           total:'0',
           sortChange: 'relevance',
           query:'',
-          page: 1,
-          pages: 1,
-          perPage: 20,
           loading:false,
           highlighter: null,
           startingPoints:{{starting_points}},
           shortcuts:{{registry_shortcuts}},
+          classesGroupByLetter:[],
+          perPage: 10,
+          page: 1,
+          pages: 1,
+          startCap:0,
+          endCap:20,
+          groupPages: false,
+          pageLimit: 20,
+          startCapLimitReached: true,
+          endCapLimitReached: false,
 				}
 			},
       methods:{
+        getNameSpaces(){
+          var self = this;
+          let res =[];
+          axios.get('/api/registry/query?facets=namespace&facet_size=100').then(res=>{
+
+            res = res.data.facets.namespace.terms.map(r => r.term);
+            let data = res.reduce((r, e) => {
+              let group = e[0];
+              if(!r[group]) r[group] = {group, children: [e]}
+              else r[group].children.push(e);
+              return r;
+            }, {});
+            res = Object.values(data)
+            self.classesGroupByLetter = _.orderBy(data, ['group'], ['asc']);
+
+          }).catch(err=>{
+           throw err;
+          });
+        },
         mark: function(keyword){
           this.highlighter.unmark();
           this.highlighter.mark(keyword);
@@ -841,18 +897,58 @@ var app = new Vue({
           });
         },
         calculatePages: function () {
-            this.pages = Math.ceil(this.total / this.perPage);
-            if(this.page > this.pages){
-              this.page = 1
+          var self= this;
+          self.pages = Math.ceil(this.total / self.perPage);
+  
+          if (self.pages > self.pageLimit) {
+            self.groupPages =  true;
+          }
+        },
+        previousGroup: function(){
+          var self = this;
+  
+          if (!self.startCapLimitReached) {
+            if (self.startCap-20 > 0) {
+              self.page = self.startCap-20
+              self.startCap = self.startCap-20
+              self.endCap = self.endCap-20
+              self.endCapLimitReached = false;
+            }else {
+              self.page = 1
+              self.startCap = 0
+              self.endCap = 20
+              self.startCapLimitReached = true;
+              self.endCapLimitReached = false;
             }
+          }
+        },
+        nextGroup: function(){
+          var self = this;
+  
+          if (!self.endCapLimitReached) {
+            if (self.endCap+20 < self.pages) {
+              self.page = self.startCap+20
+              self.startCap = self.startCap+20
+              self.endCap = self.endCap+20
+              self.startCapLimitReached = false;
+            }else {
+              self.page = self.startCap+20
+              self.startCap = self.startCap+20
+              self.endCap = self.pages
+              self.endCapLimitReached = true;
+              self.startCapLimitReached = false;
+            }
+          }
         },
         prevPage: function () {
-            if (this.page > 1)
-                this.page -= 1
+          var self= this;
+          if (self.page > 1)
+              self.page -= 1
         },
         nextPage: function () {
-            if (this.page < this.pages)
-                this.page += 1
+          var self= this;
+          if (self.page < self.pages)
+              self.page += 1
         },
         sortResults(e){
           this.sort = e.target.value;

--- a/templates/schema-viewer.html
+++ b/templates/schema-viewer.html
@@ -193,7 +193,7 @@
           </template>
         </div>
         <div>
-          <small class="text-center text-light mb-1">Validation View</small>
+          <small class="text-center text-light mb-1"><img src='/static/img/cube.svg' width="15px"> Validation View</small>
           <input id="showButton" class="form-control slider m-auto" @change="changeView()" data-tippy="Show this class only and any validation included"  type="checkbox" v-model="validationView"/>
         </div>
         <div v-if="userSchemaURL">


### PR DESCRIPTION
Add tab to browse registered namespaces or search by class name.  
Add groups to pagination to handle overflow. 

<img width="910" alt="Screen Shot 2022-04-05 at 5 09 55 PM" src="https://user-images.githubusercontent.com/23092057/161871045-33ba0f17-34fa-4a99-985d-8ca5e2f9bb37.png">
