### PR TITLE
fix: :hammer: local dev settings, broken image imports, identifier

### DIFF
--- a/nuxt-app/components/SchemaViewerForm.vue
+++ b/nuxt-app/components/SchemaViewerForm.vue
@@ -60,6 +60,11 @@ import woohoo from "@/assets/img/woohoo-01.svg";
 import oh_no from "@/assets/img/oh_no-01.svg";
 import dde_logo from "@/assets/img/dde-logo-o.svg";
 import not_right from "@/assets/img/not_right-01.svg";
+import broken from "@/assets/img/broken_root-01.svg"
+import check_validation from "@/assets/img/check_validation-01.svg"
+import check_range from "@/assets/img/check_range-01.svg"
+import check_definition from "@/assets/img/check_definition-01.svg"
+import check_label from "@/assets/img/label_issue-01.svg"
 export default {
   data: function () {
     return {
@@ -158,45 +163,45 @@ export default {
       let msg_html = "<div>";
       switch (type) {
         case "no_path_to_root":
-          msg_html += `<img src="@/assets/img/broken_root-01.svg" height="50px" alt="broken path to root"/>
+          msg_html += `<img src="` + broken +`" height="50px" alt="No path to root class"/>
                     <small class="text-primary d-block">Tip: A broken path can generate more errors, 
                         we recommend fixing this first and see if this fixes other issues.</small>`;
           break;
         case "invalid_validation_schema":
-          msg_html += `<img src="@/assets/img/check_validation-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + check_validation + `" height="50px" alt="check validation"/>`;
           break;
         case "undefined_rangeincludes":
-          msg_html += `<img src="@/assets/img/check_range-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + check_range +`" height="50px" alt="check rangeIncludes"/>`;
           break;
         case "non_class_or_property_@type":
-          msg_html += `<img src="@/assets/img/check_range-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + check_range + `" height="50px" alt="check rangeIncludes"/>`;
           break;
         case "invalid_property":
-          msg_html += `<img src="@/assets/img/check_definition-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + check_definition + `" height="50px" alt="check definition"/>`;
           break;
         case "invalid_class":
-          msg_html += `<img src="@/assets/img/check_definition-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + check_definition + `" height="50px" alt="check definition"/>`;
           break;
         case "dup_label":
-          msg_html += `<img src="@/assets/img/label_issue-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + check_label + `" height="50px" alt="check labels"/>`;
           break;
         case "unmatched_label":
-          msg_html += `<img src="@/assets/img/label_issue-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + check_label + `" height="50px" alt="check labels"/>`;
           break;
         case "missing_rangeincludes":
-          msg_html += `<img src="@/assets/img/check_range-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + check_range + `" height="50px" alt="check ranges"/>`;
           break;
         case "undefined_domainincludes_class":
-          msg_html += `<img src="@/assets/img/check_definition-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + check_definition + `" height="50px" alt="check definition"/>`;
           break;
         case "invalid_property_label":
-          msg_html += `<img src="@/assets/img/label_issue-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + check_label + `" height="50px" alt="check label"/>`;
           break;
         case "invalid_class_label":
-          msg_html += `<img src="@/assets/img/label_issue-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + check_label + `" height="50px" alt="check labels"/>`;
           break;
         default:
-          msg_html += `<img src="@/assets/img/not_right-01.svg" height="50px" alt="broken path to root"/>`;
+          msg_html += `<img src="` + not_right + `" height="50px" alt="oh no"/>`;
           break;
       }
       msg_html +=

--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -18,7 +18,7 @@ export default defineNuxtConfig({
       // to test CRUD operations you must use a proxy server, a localhost will only work
       //with GET calls, for prod a proxy server/handler must be used.
       apiUrl:
-        process.env.NODE_ENV == "development" ? "http://localhost:8000" : "",
+        process.env.NODE_ENV == "development" ? "http://localhost" : "",
     },
   },
   // https://github.com/nuxt/framework/discussions/3823

--- a/nuxt-app/store/modules/guide.js
+++ b/nuxt-app/store/modules/guide.js
@@ -212,6 +212,15 @@ export const guide = {
       if (state.schema.validation.properties.hasOwnProperty(selection.name)) {
         state.schema.validation.properties[selection.name]["value"] =
           selection.value;
+        //prefill identifier with URL field if available
+        if (
+          selection.name == 'url' &&
+          'identifier' in state.schema.validation.properties &&
+          !state.schema.validation.properties['identifier']["value"] &&
+          !state.schema.validation?.required?.includes('identifier')
+        ){
+          state.schema.validation.properties['identifier']["value"] = selection.value;
+        }
         //check for duplicate keys or plural names
         if (
           selection.name + "s" in state.schema.validation.properties &&


### PR DESCRIPTION
change to local dev settings to allow for nginx proxy
fixes broken images in modals
sets up requirements for handling guides where an identifier is not required by the schema but it's required by the backend:
a URL will be used for the identifier field when available.