### PR TITLE
feat: :sparkles: add dev and prod mode to docker webapp

### DIFF
--- a/docker/Dockerfile_webapp.development
+++ b/docker/Dockerfile_webapp.development
@@ -1,0 +1,21 @@
+# Use Node 18 Alpine for a minimal environment
+FROM node:18-alpine
+
+RUN echo "Running Nuxt App in DEVELOPMENT mode" && \
+    apk update && \
+    apk upgrade && \
+    apk --no-cache add git
+
+RUN git clone https://github.com/biothings/discovery-app.git
+
+WORKDIR /discovery-app/nuxt-app
+
+RUN npm install
+
+ENV PORT=3000
+ENV NODE_ENV=development
+
+EXPOSE 3000
+
+# Run in development mode
+CMD ["npm", "run", "dev"]

--- a/docker/Dockerfile_webapp.production
+++ b/docker/Dockerfile_webapp.production
@@ -1,6 +1,7 @@
 FROM node:18-alpine
 
-RUN apk update && \
+RUN echo "Running Nuxt App in PRODUCTION mode" && \
+    apk update && \
     apk upgrade && \
     apk --no-cache add git
 

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -1,0 +1,5 @@
+# docker-compose.override.yml
+services:
+  webapp:
+    volumes:
+      - ../nuxt-app:/discovery-app/nuxt-app  # Enable hot reloading in development

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   nginx:
     image: nginx:stable-alpine
     ports:
-      - "8000:8000"
+      - "8080:8080"
     volumes:
       - ./nginx_conf.d:/etc/nginx/conf.d
     depends_on:
@@ -39,11 +39,20 @@ services:
     networks:
       - net0
 
+# To run in development mode:
+# WEB_APP_MODE=development docker compose -f docker-compose.yml -f docker-compose.override.yml up --detach
+
+# To run in prodction mode:
+# WEB_APP_MODE=production docker compose up --detach
+
   webapp:
     build:
-      dockerfile: Dockerfile_webapp
+      dockerfile: Dockerfile_webapp.${WEB_APP_MODE:-production} # Defaults to Dockerfile.prod if WEB_APP_MODE is not set
+    environment:
+      - NODE_ENV=${WEB_APP_MODE:-production}
     ports:
-      - "3000"
+      - "3000:3000"
+      - "24679:24679"    # expose HMR port for dev
     restart: on-failure
     networks:
       - net0

--- a/docker/nginx_conf.d/discovery-app.conf
+++ b/docker/nginx_conf.d/discovery-app.conf
@@ -14,7 +14,7 @@ upstream discovery_frontend {
 
 server {
     server_name localhost;
-    listen 8000;
+    listen 8080;
 
     location ~ ^/(sitemap.xml) {
          proxy_pass http://discovery_frontend;


### PR DESCRIPTION
### Build and start with webapp in production mode. (not editable)

```bash
cd docker
 WEB_APP_MODE=production docker compose up --detach
```

### Build and start with webapp in development mode. (editable)

```bash
cd docker
WEB_APP_MODE=development docker compose -f docker-compose.yml -f docker-compose.override.yml up --detach
```