### PR TITLE
Increased the query size limit Issue #312

### DIFF
--- a/discovery/handlers/api/schema.py
+++ b/discovery/handlers/api/schema.py
@@ -125,7 +125,7 @@ class SchemaRegistryHandler(APIBaseHandler):
             "field": {"type": str, "default": "*", "aslias": "fields"},
             "verbose": {"type": bool, "default": False, "alias": ["v"]},
             "start": {"type": int, "default": 0, "alias": ["from", "skip"]},
-            "size": {"type": int, "default": 10, "max": 20, "alias": "skip"},
+            "size": {"type": int, "default": 10, "max": 100, "alias": "skip"},
             "context": {"type": bool, "default": True},  # consider not default in future
             "source": {"type": bool, "default": True},
         },


### PR DESCRIPTION
Increased the registry schema handler to showcase a limit now of 100 hits, increasing view limit from original size limit of 20.  

i.e https://discovery.biothings.io/api/registry?field=_meta&size=100
