### PR TITLE
Add schema owner change functionality

### DIFF
--- a/discovery/registry/schemas.py
+++ b/discovery/registry/schemas.py
@@ -189,6 +189,14 @@ def add(namespace, url, user, doc=None, overwrite=False):
             file.save()
             count = _add_schema_class(doc, namespace)
             return count
+        elif is_ownership_changed(namespace, user):
+            schema = ESSchemaFile.get(id=namespace)
+            schema._meta.username = user
+            schema._status.refresh_ts = current_date
+            schema._status.refresh_status = 299
+            schema._status.refresh_msg = "ownership updated, no content changes"
+            schema.save(skip_ts=True)
+            return len(list(get_classes(namespace)))
         else:
             return 0
 
@@ -333,6 +341,16 @@ def is_schema_updated(namespace, current_doc):
         if current_doc[key] != existing_doc[key]:
             return True
     return False
+
+
+def is_ownership_changed(namespace, user):
+    """
+    Comparison method
+    Compare the existing schema's registered owner (username) with the given user.
+    Return True if the owner differs (ownership change), else False.
+    """
+    meta_data = get_meta(namespace)
+    return meta_data.get("username") != user
 
 
 def delete(namespace):

--- a/discovery/registry/schemas.py
+++ b/discovery/registry/schemas.py
@@ -338,7 +338,9 @@ def is_schema_updated(namespace, current_doc):
     """
     existing_doc = get(namespace)
     for key in current_doc:
-        if current_doc[key] != existing_doc[key]:
+        current_val = json.dumps(current_doc[key], sort_keys=True)
+        existing_val = json.dumps(existing_doc.get(key), sort_keys=True)
+        if current_val != existing_val:
             return True
     return False
 

--- a/tests/test_schema_status_update.py
+++ b/tests/test_schema_status_update.py
@@ -115,3 +115,39 @@ class TestSchemaStatus(DiscoveryTestCase):
         test_schema = ESSchemaFile.get(id='n3c')
         assert test_schema._status.refresh_status == 299
         assert test_schema._status.refresh_msg == 'new version available and update successful'
+
+    def test_update_ownership_change_299(self):
+        """
+        ✅ Success case: schema content is unchanged but the owner (username) differs.
+
+        The update should transfer ownership without altering the schema content.
+
+        Expected:
+        - _meta.username: updated to the new owner
+        - refresh_status: 299
+        - refresh_msg: 'ownership updated, no content changes'
+        """
+        success_url = 'https://raw.githubusercontent.com/data2health/schemas/master/N3C/N3CDataset.json'
+
+        namespace = "ownership_test"
+        original_owner = "minions@example.com"
+        new_owner = "newowner@example.com"
+
+        with open("./tests/test_schema/mock_updated_schema.json") as f:
+            _doc = json.load(f)
+
+        # Start from a clean state and register the schema under the original owner.
+        if schemas.exists(namespace):
+            schemas.delete(namespace)
+        schemas.add(namespace, url=self.test_url, user=original_owner, doc=_doc)
+        ESSchemaFile._index.refresh()  # ensure the new doc is searchable before update
+        # is_ownership_changed should detect the differing user.
+        assert schemas.is_ownership_changed(namespace, new_owner) is True
+        assert schemas.is_ownership_changed(namespace, original_owner) is False
+
+        # Update with identical content but a new owner -> ownership transfer branch.
+        schemas.update(namespace, user=new_owner, url=self.test_url, doc=_doc)
+
+        test_schema = ESSchemaFile.get(id=namespace)
+        assert test_schema._meta.username == new_owner
+        assert test_schema._status.refresh_status == 299


### PR DESCRIPTION
The current code in DDE updates schema documents by comparison of original documents against the incoming _new_ version. If a schema document has been altered, the current functionality recognizes that and updates the schema. 
**Issue:** When a schemas document isn't changed, but the ownership has, the schema won't update to reflect new ownership.  
**Solution:** A functionality has been added to handle ownership transfer when there is no document change. This individual function has been added on top of the already existing decision condition, requiring no major logic change for update functionality. 
* Added `is_ownership_changed()` function to `~/registry/schemas.py`
* Added test, `test_update_ownership_change_299()`, into `test_schema_update.py`
* Ran original and new tests, all ran with `PASS` status